### PR TITLE
language cannot be overridable

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -198,7 +198,6 @@ const CONFIG_STEPS = <ConfigStep[]>[
         .newSelectSingle()
         .setId('language')
         .setName('Report Language')
-        .setAllowOverride(true)
         .setHelpText('The language to use for report column names. If unset, defaults to the language you\'ve selected in your Google account.');
 
       languages.forEach((language) => {


### PR DESCRIPTION
### Description:

Unfortunately, since the language changes the data schema in looker studio (column display names are part of the schema), changing it after configuring the connector will have no effect. So this PR disallows language from being overridable.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
