### PR TITLE
Fix "Too many properties to enumerate error"

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -12,7 +12,7 @@ const env = typeof process === 'undefined' ? null : process.env;
 export default <Record<string, string>>{
   DEBUG: properties.getProperty('DEBUG') || env?.DEBUG || '0',
   CONFIG_REQUEST_CACHE_TTL_SECS: properties.getProperty('CONFIG_REQUEST_CACHE_TTL_SECS') || env?.CONFIG_REQUEST_CACHE_TTL_SECS || '60',
-  MAX_ROWS_TO_FETCH_PER_REQUEST: properties.getProperty('MAX_ROWS_TO_FETCH_PER_REQUEST') || env?.MAX_ROWS_TO_FETCH_PER_REQUEST || '100000',
+  MAX_ROWS_TO_FETCH_PER_REQUEST: properties.getProperty('MAX_ROWS_TO_FETCH_PER_REQUEST') || env?.MAX_ROWS_TO_FETCH_PER_REQUEST || '50000',
   SCRIPT_RUNTIME_LIMIT: properties.getProperty('SCRIPT_RUNTIME_LIMIT') || env?.SCRIPT_RUNTIME_LIMIT || '350',
   API_REQUEST_SOURCE_IDENTIFIER: properties.getProperty('API_REQUEST_SOURCE_IDENTIFIER') || env?.API_REQUEST_SOURCE_IDENTIFIER || 'fromLooker',
   API_REQUEST_RETRY_LIMIT_IN_SECS: properties.getProperty('API_REQUEST_RETRY_LIMIT_IN_SECS') || env?.API_REQUEST_RETRY_LIMIT_IN_SECS || '120',


### PR DESCRIPTION
### Description:

In PHP, the Matomo API returns a report's rows as an array with numeric keys. There are, however, special rows that can have a negative index (like the summary row). When not used, the JSON printed out will be a normal array (ie, `[...]`). But when those special rows are included, the JSON will be an object (ie, `{...}`). The problem with this is that there is a hard limit on the number of keys that can be included in a JavaScript object, 65535. So if the number of rows exceeds this limit, an exception will be thrown when trying to parse the Matomo API's JSON response.

Working around this issue by limiting the maximum number of rows fetched at a time to 50,000.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
