### PR TITLE
fix error that occurs when querying older Matomos without metricTypes metadata

### DIFF
--- a/src-test/callFunctionInTest.ts
+++ b/src-test/callFunctionInTest.ts
@@ -7,7 +7,7 @@
 
 export function callFunctionInTest(functionName: string, testName: string, ...params: unknown[]) {
   try {
-    console.log(`calling ${functionName} in test "${testName}}`);
+    console.log(`calling ${functionName} in test "${testName}"`);
 
     // there is no global object (like window) in apps script, so this is how we get a global function by name
     const fn = eval(functionName);

--- a/src-test/callFunctionInTest.ts
+++ b/src-test/callFunctionInTest.ts
@@ -5,8 +5,10 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
-export function callFunctionInTest(functionName: string, ...params: unknown[]) {
+export function callFunctionInTest(functionName: string, testName: string, ...params: unknown[]) {
   try {
+    console.log(`calling ${functionName} in test "${testName}}`);
+
     // there is no global object (like window) in apps script, so this is how we get a global function by name
     const fn = eval(functionName);
     const result = fn(...params);

--- a/src/api.ts
+++ b/src/api.ts
@@ -253,7 +253,7 @@ export function fetchAll(requests: MatomoRequestParams[], options: ApiFetchOptio
 
     if (errorResponses.length === 1) {
       const { method, params } = requests[errorResponses[0].index];
-      throwUnexpectedError(new Error(`API method ${method} failed with: "${errorResponses[0].message}". (params = ${JSON.stringify(params)})`), 'api client');
+      throwUnexpectedError(new Error(`API method ${method} failed (params = ${JSON.stringify(params)}): "${errorResponses[0].message}".`), 'api client');
     } else if (errorResponses.length > 1) {
       throwUnexpectedError(new Error(`${errorResponses.length} API methods failed.`), 'api client');
     }

--- a/src/data.ts
+++ b/src/data.ts
@@ -408,6 +408,8 @@ function getFieldsFromReportMetadata(reportMetadata: Api.ReportMetadata, goals: 
       allMetrics = { ...allMetrics, ...metricsForEachGoal({ 'conversion_rate': 'Conversion Rate' }, goals) };
     }
 
+    reportMetadata.metricTypes = reportMetadata.metricTypes || {};
+
     // pre 5.1.0, the overall conversions and revenue sum metrics were not present in metadata output,
     // but the data exists in the actual API output
     if (reportMetadata.module !== 'Actions') {

--- a/tests/appscript/api.spec.ts
+++ b/tests/appscript/api.spec.ts
@@ -128,6 +128,8 @@ describe('api', () => {
         },
       });
 
+      await new Promise((resolve) => setTimeout(resolve, 5000));
+
       // use the mock server's path that forces a random error
       const result = await Clasp.run('setCredentials', {
         userToken: {

--- a/tests/appscript/data.spec.ts
+++ b/tests/appscript/data.spec.ts
@@ -301,7 +301,7 @@ describe('data', () => {
     });
 
 
-    it.only('should return all data when no filter limit is set', async () => {
+    it('should return all data when no filter limit is set', async () => {
       await Clasp.setScriptProperties({
         MAX_ROWS_TO_FETCH_PER_REQUEST: '500',
       }, true);

--- a/tests/appscript/data.spec.ts
+++ b/tests/appscript/data.spec.ts
@@ -301,7 +301,7 @@ describe('data', () => {
     });
 
 
-    it('should return all data when no filter limit is set', async () => {
+    it.only('should return all data when no filter limit is set', async () => {
       await Clasp.setScriptProperties({
         MAX_ROWS_TO_FETCH_PER_REQUEST: '500',
       }, true);

--- a/tests/utilities/clasp.ts
+++ b/tests/utilities/clasp.ts
@@ -73,7 +73,8 @@ class Clasp {
   }
 
   async run(functionName: string, ...args: any[]) {
-    return this.runExecutable(['run', '-p', JSON.stringify([functionName, ...args]), 'callFunctionInTest']);
+    const testName = expect.getState().currentTestName;
+    return this.runExecutable(['run', '-p', JSON.stringify([functionName, testName, ...args]), 'callFunctionInTest']);
   }
 
   async setScriptProperties(properties: Record<string, string>, deleteExisting = false) {


### PR DESCRIPTION
### Description:

As title. Also includes a change to log the current test being executed in the app script function being run so it's easier to find logs for a specific test failure.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
