### PR TITLE
workaround bug in matomo: showColumns=bounce_rate does not work with API.get

### DIFF
--- a/src/data.ts
+++ b/src/data.ts
@@ -225,8 +225,6 @@ function getReportData(request: GoogleAppsScript.Data_Studio.Request<ConnectorPa
   }
 
   const SHOW_COLUMNS_UNSUPPORTED_METHODS = [
-    'API.get', // only works for some metrics
-    'VisitFrequency.get',
     'Contents.getContentPieces',
     'Contents.getContentNames',
     'Actions.getPageUrlsFollowingSiteSearch',
@@ -234,7 +232,9 @@ function getReportData(request: GoogleAppsScript.Data_Studio.Request<ConnectorPa
 
   let showColumns;
   // showColumns does not work correctly with some API methods
-  if (!SHOW_COLUMNS_UNSUPPORTED_METHODS.includes(apiMethod)) {
+  if (!SHOW_COLUMNS_UNSUPPORTED_METHODS.includes(apiMethod)
+    && reportParams.apiAction !== 'get' // showColumns does not work for API methods like API.get or VisitFrequency.get
+  ) {
     showColumns = (requestedFields.map(({name}) => name)).join(',');
   }
 

--- a/src/data.ts
+++ b/src/data.ts
@@ -225,6 +225,7 @@ function getReportData(request: GoogleAppsScript.Data_Studio.Request<ConnectorPa
   }
 
   const SHOW_COLUMNS_UNSUPPORTED_METHODS = [
+    'API.get', // only works for some metrics
     'VisitFrequency.get',
     'Contents.getContentPieces',
     'Contents.getContentNames',
@@ -290,8 +291,8 @@ function getReportData(request: GoogleAppsScript.Data_Studio.Request<ConnectorPa
       filter_limit: `${limitToUse}`,
       filter_offset: `${offset}`,
       showColumns,
-      apiModule: null,
-      apiAction: null,
+      apiModule: undefined,
+      apiAction: undefined,
     };
 
     if (reportParams.apiModule !== 'Goals' && typeof params.idGoal === 'undefined') {

--- a/tests/appscript/data.spec.ts
+++ b/tests/appscript/data.spec.ts
@@ -438,6 +438,24 @@ describe('data', () => {
       expect(result).toEqual(getExpectedResponse(result, 'data', 'Events.getName_withDateDimension_date'));
     });
 
+    it('should correctly fetch a single column from a **.get API method', async () => {
+      let result = await Clasp.run('getData', {
+        configParams: {
+          idsite: env.APPSCRIPT_TEST_IDSITE,
+          report: JSON.stringify({ apiModule: 'API', apiAction: 'get' }),
+          filter_limit: 5,
+        },
+        dateRange: {
+          startDate: DATE_TO_TEST,
+          endDate: DATE_TO_TEST,
+        },
+        fields: [
+          { name: 'bounce_rate' },
+        ],
+      });
+      expect(result).toEqual(getExpectedResponse(result, 'data', `API.get_singleProcessedMetric`));
+    });
+
     it('should correctly fetch data for a date range spanning multiple days', async () => {
       await Clasp.run('setScriptProperties', {}, true);
 

--- a/tests/appscript/expected/data_API.get_singleProcessedMetric.json
+++ b/tests/appscript/expected/data_API.get_singleProcessedMetric.json
@@ -1,0 +1,22 @@
+{
+  "filtersApplied": false,
+  "rows": [
+    {
+      "values": [
+        "0.73"
+      ]
+    }
+  ],
+  "schema": [
+    {
+      "dataType": "NUMBER",
+      "label": "Bounce Rate",
+      "name": "bounce_rate",
+      "semantics": {
+        "conceptType": "METRIC",
+        "isReaggregatable": false,
+        "semanticType": "PERCENT"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
### Description:

So disable the use of showColumns with that API method in the connector.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
